### PR TITLE
remove printing of type

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -31,6 +31,8 @@ func NewGoSNMP(target, community string, version SnmpVersion, timeout int64) (*G
 			fmt.Errorf("Error establishing connection to host: %s\n",
 			err.Error())
 	}
+	defer conn.Close()
+
 	var s *GoSNMP
 	//if c, ok := conn.(net.UDPConn); ok {
 	s = &GoSNMP{target, community, version, time.Duration(timeout) * time.Second, conn}


### PR DESCRIPTION
Maybe the library should support a debug flag. Otherwise straight
fmt.Printf's get mixed in with the calling program's output.
