### PR TITLE
prevent panics being passed

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -77,6 +77,11 @@ func (x *GoSNMP) Debug(data []byte) (*SnmpPacket, error) {
 // Sends an SNMP GET request to the target. Returns a Variable with the response or an error
 func (x *GoSNMP) Get(oid string) (*SnmpPacket, error) {
 	var err error
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("%v", e)
+		}
+	}()
 
 	// Set timeouts on the connection
 	deadline := time.Now()


### PR DESCRIPTION
It's preferable for Go packages to report problems as errors
rather than as panics. (I was regularly getting panics due to
some funky (bad) code I'd written in a calling program).

See pp215-216 of Summerfield "Programming in Go".
