### PR TITLE
Allow SNMP target to use a port other than 161.

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -21,11 +21,17 @@ type GoSNMP struct {
 	Log       *l.Logger
 }
 
+var DEFAULT_PORT = 161
+
 // Creates a new SNMP Client. Target is the IP address, Community the SNMP Community String and Version the SNMP version.
 // Currently only v2c is supported. Timeout parameter is measured in seconds.
 func NewGoSNMP(target, community string, version SnmpVersion, timeout int64) (*GoSNMP, error) {
+	if !strings.Contains(target, ":") {
+		target = fmt.Sprintf("%s:%d", target, DEFAULT_PORT)
+	}
+
 	// Open a UDP connection to the target
-	conn, err := net.DialTimeout("udp", fmt.Sprintf("%s:161", target), time.Duration(timeout)*time.Second)
+	conn, err := net.DialTimeout("udp", target, time.Duration(timeout)*time.Second)
 
 	if err != nil {
 		return nil, fmt.Errorf("Error establishing connection to host: %s\n", err.Error())

--- a/gosnmp_test.go
+++ b/gosnmp_test.go
@@ -67,3 +67,18 @@ func TestWalk(t *testing.T) {
 	}
 
 }
+
+// Test SNMP connections with different ports
+func TestConnect(t *testing.T) {
+        t.Log("Running connection tests")
+        targets := []string{"localhost", "localhost:161"}
+
+        for _, target := range targets {
+                _, err := NewGoSNMP(target, "public", Version2c, 5)
+
+                if err != nil {
+                        t.Fatalf("Unable to connect to %s: %s\n", target, err)
+                }
+        }
+}
+


### PR DESCRIPTION
NewGoSNMP() had the default SNMP port (161) hardcoded in the target.
Allowing the caller to specify the port provides a more flexibile
approach.

Fixes #12
