### PR TITLE
Unmarshal raw packets

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -138,6 +138,8 @@ func decodeValue(valueType Asn1BER, data []byte) (retVal *Variable, err error) {
 
 		retVal.Type = Counter64
 		retVal.Value = ret
+	case Null:
+		retVal.Value = nil
 	case Sequence:
 		// NOOP
 		retVal.Value = data
@@ -147,15 +149,18 @@ func decodeValue(valueType Asn1BER, data []byte) (retVal *Variable, err error) {
 	case GetRequest:
 		// NOOP
 		retVal.Value = data
+	case GetBulkRequest:
+		// NOOP
+		retVal.Value = data
 	case NoSuchInstance:
 		return nil, fmt.Errorf("No such instance")
 	case NoSuchObject:
 		return nil, fmt.Errorf("No such object")
 	default:
-		err = fmt.Errorf("Unable to decode %#v - not implemented", valueType)
+		err = fmt.Errorf("Unable to decode %s %#v - not implemented", valueType, valueType)
 	}
 
-	return retVal, nil
+	return retVal, err
 }
 
 // Parses UINT16

--- a/packet.go
+++ b/packet.go
@@ -97,12 +97,13 @@ func Unmarshal(packet []byte) (*SnmpPacket, error) {
 		if err != nil {
 			log.Debug("Unable to parse SNMP PDU: %s\n", err.Error())
 		}
+		response.RequestType = rawPDU.Type
 
 		switch rawPDU.Type {
 		default:
 			log.Debug("Unsupported SNMP Packet Type %s\n", rawPDU.Type.String())
 			log.Debug("PDU Size is %d\n", rawPDU.DataLength)
-		case GetRequest, GetResponse:
+		case GetRequest, GetResponse, GetBulkRequest:
 			log.Debug("SNMP Packet is %s\n", rawPDU.Type.String())
 			log.Debug("PDU Size is %d\n", rawPDU.DataLength)
 			cursor += rawPDU.HeaderLength


### PR DESCRIPTION
GetBulkRequest:

```
go run src/github.com/schuk/gosnmp/examples/example.go -debug="302602010104067075626c6963a51902045e578a9302010002010a300b300906052b060102010500"
Running in debug mode
2014/01/23 15:06:14 [DEBUG] packet.go:51 (github.com/schuk/gosnmp.Unmarshal) Begin SNMP Packet unmarshal
2014/01/23 15:06:14 [DEBUG] packet.go:67 (github.com/schuk/gosnmp.Unmarshal) Packet sanity verified, we got all the bytes (38)
2014/01/23 15:06:14 [DEBUG] packet.go:80 (github.com/schuk/gosnmp.Unmarshal) Parsed Version 1
2014/01/23 15:06:14 [DEBUG] packet.go:92 (github.com/schuk/gosnmp.Unmarshal) Parsed community public
2014/01/23 15:06:14 [DEBUG] packet.go:108 (github.com/schuk/gosnmp.Unmarshal) SNMP Packet is GetBulkRequest
2014/01/23 15:06:14 [DEBUG] packet.go:108 (github.com/schuk/gosnmp.Unmarshal) PDU Size is 25
2014/01/23 15:06:14 [DEBUG] packet.go:121 (github.com/schuk/gosnmp.Unmarshal) Parsed Request ID: 1582795411
2014/01/23 15:06:14 [DEBUG] packet.go:149 (github.com/schuk/gosnmp.Unmarshal) Request ID: 147 Error: 0 Error Index: 10
2014/01/23 15:06:14 [DEBUG] packet.go:159 (github.com/schuk/gosnmp.Unmarshal) Parsing var bind response (Cursor at 29/40)
2014/01/23 15:06:14 [DEBUG] packet.go:170 (github.com/schuk/gosnmp.Unmarshal) Varbind length: 2/9
2014/01/23 15:06:14 [DEBUG] packet.go:170 (github.com/schuk/gosnmp.Unmarshal) Parsing OID (Cursor at 31)
2014/01/23 15:06:14 [DEBUG] packet.go:180 (github.com/schuk/gosnmp.Unmarshal) OID (&{ObjectIdentifier 2 5 [43 6 1 2 1] 0xc210058a00}) Field was 5 bytes
2014/01/23 15:06:14 [DEBUG] packet.go:191 (github.com/schuk/gosnmp.Unmarshal) Value field was 0 bytes
2014/01/23 15:06:14 [DEBUG] packet.go:193 (github.com/schuk/gosnmp.Unmarshal) Varbind decoding success
.1.3.6.1.2.1 -> <nil>
```

BulkRequest Response:

```
go run src/github.com/schuk/gosnmp/examples/example.go -debug="3082013b02010104067075626c6963a282012c02045e578a930201000201003082011c301e06082b0601020101010004124c696e75782054532d34373020342e302e353018060a2b060102010109010201060a2b060106030b020301013017060a2b06010201010901020206092b060106030f0201013017060a2b06010201010901020306092b060106030a0301013014060a2b06010201010901020406062b06010603013014060a2b06010201010901020506062b06010201313014060a2b06010201010901020606062b06010201043014060a2b06010201010901020706062b06010201323017060a2b06010201010901020806092b0601060310020201303d060a2b060102010109010301042f546865204d494220666f72204d6573736167652050726f63657373696e6720616e64204469737061746368696e672e"
```

GetRequest:

```
go run src/github.com/schuk/gosnmp/examples/example.go -debug="302902010004067075626c6963a01c0204304471b6020100020100300e300c06082b060102010105000500" 
Running in debug mode
2014/01/23 15:03:44 [DEBUG] packet.go:51 (github.com/schuk/gosnmp.Unmarshal) Begin SNMP Packet unmarshal
2014/01/23 15:03:44 [DEBUG] packet.go:67 (github.com/schuk/gosnmp.Unmarshal) Packet sanity verified, we got all the bytes (41)
2014/01/23 15:03:44 [DEBUG] packet.go:80 (github.com/schuk/gosnmp.Unmarshal) Parsed Version 0
2014/01/23 15:03:44 [DEBUG] packet.go:92 (github.com/schuk/gosnmp.Unmarshal) Parsed community public
2014/01/23 15:03:44 [DEBUG] packet.go:108 (github.com/schuk/gosnmp.Unmarshal) SNMP Packet is GetRequest
2014/01/23 15:03:44 [DEBUG] packet.go:108 (github.com/schuk/gosnmp.Unmarshal) PDU Size is 28
2014/01/23 15:03:44 [DEBUG] packet.go:121 (github.com/schuk/gosnmp.Unmarshal) Parsed Request ID: 809791926
2014/01/23 15:03:44 [DEBUG] packet.go:149 (github.com/schuk/gosnmp.Unmarshal) Request ID: 182 Error: 0 Error Index: 0
2014/01/23 15:03:44 [DEBUG] packet.go:159 (github.com/schuk/gosnmp.Unmarshal) Parsing var bind response (Cursor at 29/43)
2014/01/23 15:03:44 [DEBUG] packet.go:170 (github.com/schuk/gosnmp.Unmarshal) Varbind length: 2/12
2014/01/23 15:03:44 [DEBUG] packet.go:170 (github.com/schuk/gosnmp.Unmarshal) Parsing OID (Cursor at 31)
2014/01/23 15:03:44 [DEBUG] packet.go:180 (github.com/schuk/gosnmp.Unmarshal) OID (&{ObjectIdentifier 2 8 [43 6 1 2 1 1 5 0] 0xc210058a00}) Field was 8 bytes
2014/01/23 15:03:44 [DEBUG] packet.go:191 (github.com/schuk/gosnmp.Unmarshal) Value field was 0 bytes
2014/01/23 15:03:44 [DEBUG] packet.go:193 (github.com/schuk/gosnmp.Unmarshal) Varbind decoding success
.1.3.6.1.2.1.1.5.0 -> <nil>
```

GetResponse:

```
[root@vagrant-precise-64  goprojects (master)]$ go run src/github.com/schuk/gosnmp/examples/example.go -debug="303202010004067075626c6963a2250204304471b60201000201003017301506082b0601020101050004094e4153444245393244"
Running in debug mode
2014/01/23 15:04:21 [DEBUG] packet.go:51 (github.com/schuk/gosnmp.Unmarshal) Begin SNMP Packet unmarshal
2014/01/23 15:04:21 [DEBUG] packet.go:67 (github.com/schuk/gosnmp.Unmarshal) Packet sanity verified, we got all the bytes (50)
2014/01/23 15:04:21 [DEBUG] packet.go:80 (github.com/schuk/gosnmp.Unmarshal) Parsed Version 0
2014/01/23 15:04:21 [DEBUG] packet.go:92 (github.com/schuk/gosnmp.Unmarshal) Parsed community public
2014/01/23 15:04:21 [DEBUG] packet.go:108 (github.com/schuk/gosnmp.Unmarshal) SNMP Packet is GetResponse
2014/01/23 15:04:21 [DEBUG] packet.go:108 (github.com/schuk/gosnmp.Unmarshal) PDU Size is 37
2014/01/23 15:04:21 [DEBUG] packet.go:121 (github.com/schuk/gosnmp.Unmarshal) Parsed Request ID: 809791926
2014/01/23 15:04:21 [DEBUG] packet.go:149 (github.com/schuk/gosnmp.Unmarshal) Request ID: 182 Error: 0 Error Index: 0
2014/01/23 15:04:21 [DEBUG] packet.go:159 (github.com/schuk/gosnmp.Unmarshal) Parsing var bind response (Cursor at 29/52)
2014/01/23 15:04:21 [DEBUG] packet.go:170 (github.com/schuk/gosnmp.Unmarshal) Varbind length: 2/21
2014/01/23 15:04:21 [DEBUG] packet.go:170 (github.com/schuk/gosnmp.Unmarshal) Parsing OID (Cursor at 31)
2014/01/23 15:04:21 [DEBUG] packet.go:180 (github.com/schuk/gosnmp.Unmarshal) OID (&{ObjectIdentifier 2 8 [43 6 1 2 1 1 5 0] 0xc210058a40}) Field was 8 bytes
2014/01/23 15:04:21 [DEBUG] packet.go:191 (github.com/schuk/gosnmp.Unmarshal) Value field was 9 bytes
2014/01/23 15:04:21 [DEBUG] packet.go:193 (github.com/schuk/gosnmp.Unmarshal) Varbind decoding success
.1.3.6.1.2.1.1.5.0 -> NASDBE92D
```
