### PR TITLE
Optimize oidToString

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -345,10 +345,11 @@ func marshalPDU(pdu *SnmpPDU) ([]byte, error) {
 }
 
 func oidToString(oid []int) (ret string) {
-	for _, i := range oid {
-		ret = ret + fmt.Sprintf(".%d", i)
+	values := make([]interface{}, len(oid))
+	for i, v := range oid {
+		values[i] = v
 	}
-	return
+	return fmt.Sprintf(strings.Repeat(".%d", len(oid)), values...)
 }
 
 func marshalOID(oid string) ([]byte, error) {


### PR DESCRIPTION
In profiling my own program, I found a lot of time spent in oidToString.  The problem is that it's a) calling Sprintf for every octet in the oid and b) doing string concat for every octet in the oid. This patch fixes that.

The one thing I don't like about my patch is that it copies the []int to a []interface{}.  It does that so it can be passed to the variadic Sprintf function. I'm new to Go, so maybe I just don't know a better way to do that "cast to []interface{}".  At least it doesn't need to expand the values slice.
