### PR TITLE
added support for endOfMib view in snmpbulkwalk

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -35,6 +35,7 @@ const (
 	SetRequest               = 0xa3
 	Trap                     = 0xa4
 	GetBulkRequest           = 0xa5
+	EndOfMibView             = 0x82
 )
 
 // String representations of each SNMP Data Type
@@ -61,6 +62,7 @@ var dataTypeStrings = map[Asn1BER]string{
 	SetRequest:       "SetRequest",
 	Trap:             "Trap",
 	GetBulkRequest:   "GetBulkRequest",
+	EndOfMibView:     "endOfMib",
 }
 
 func (dataType Asn1BER) String() string {
@@ -149,6 +151,9 @@ func decodeValue(valueType Asn1BER, data []byte) (retVal *Variable, err error) {
 	case GetRequest:
 		// NOOP
 		retVal.Value = data
+	case EndOfMibView:
+		retVal.Type = EndOfMibView
+		retVal.Value = "endOfMib"
 	case GetBulkRequest:
 		// NOOP
 		retVal.Value = data

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -79,6 +79,9 @@ func (x *GoSNMP) _bulkWalk(max_repetitions uint8, searching_oid string, root_oid
 		return
 	}
 	for i, v := range response.Variables {
+		if v.Value == "endOfMib" {
+			return
+		}
 		// is this variable still in the requested oid range
 		if strings.HasPrefix(v.Name, root_oid) {
 			results = append(results, v)


### PR DESCRIPTION
now snmpbulkwalk can correctly handle snmpdatatype 0x82 (endOfMibView); before only last chunk of bulkwalk was returned
