### PR TITLE
StreamWalk need return nil

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -96,7 +96,7 @@ func (x *GoSNMP) StreamWalk(oid string, c chan SnmpPDU) error {
 
 	}
 	close(c)
-	return
+	return nil
 }
 
 func (x *GoSNMP) BulkWalk(max_repetitions uint8, oid string) (results []SnmpPDU, err error) {


### PR DESCRIPTION
fix `github.com/alouca/gosnmp/gosnmp.go:99: not enough arguments to return` error