### PR TITLE
add endOfMib checking to avoid endless looping

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -82,6 +82,9 @@ func (x *GoSNMP) StreamWalk(oid string, c chan SnmpPDU) error {
 		if res != nil {
 			if len(res.Variables) > 0 {
 				if strings.Index(res.Variables[0].Name, requestOid) > -1 {
+					if res.Variables[0].Value == "endOfMib" {
+						break
+					}
 					c <- res.Variables[0]
 					// Set to the next
 					oid = res.Variables[0].Name


### PR DESCRIPTION
When starting past where you're able to start in StreamWalk,
you can get an endless loop of endOfMibs.  This is avoided in
BulkWalk by explicitly checking for endOfMib but not in
StreamWalk.