### PR TITLE
Changed Counter32, Gauge32, and Counter64 to uint64

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -108,11 +108,8 @@ func decodeValue(valueType Asn1BER, data []byte) (retVal *Variable, err error) {
 		retVal.Type = IpAddress
 		retVal.Value = net.IP{data[0], data[1], data[2], data[3]}
 	// Counter32
-	case Counter32:
-		ret, err := parseInt(data)
-		if err != nil {
-			break
-		}
+	case Counter32:		
+		ret := Uvarint(data)
 		retVal.Type = Counter32
 		retVal.Value = ret
 	case TimeTicks:
@@ -124,20 +121,11 @@ func decodeValue(valueType Asn1BER, data []byte) (retVal *Variable, err error) {
 		retVal.Value = ret
 	// Gauge32
 	case Gauge32:
-		ret, err := parseInt(data)
-		if err != nil {
-			break
-		}
+		ret := Uvarint(data)
 		retVal.Type = Gauge32
 		retVal.Value = ret
 	case Counter64:
-		ret, err := parseInt64(data)
-
-		// Decode it
-		if err != nil {
-			break
-		}
-
+		ret := Uvarint(data)
 		retVal.Type = Counter64
 		retVal.Value = ret
 	case Null:


### PR DESCRIPTION
These data types are asserting incorrectly because they are being decoded incorrectly. These types are all non-negative as per the spec, and casting them to signed integers is causing them to sometimes show up as negative numbers. I'm not 100% how to error check these similar to the parseInt() function, but this is working on my application now.