### PR TITLE
Remove unused err

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -227,13 +227,6 @@ func (x *GoSNMP) sendPacket(packet *SnmpPacket) (*SnmpPacket, error) {
 // GetNext sends an SNMP Get Next Request to the target. Returns the next
 // variable response from the OID given or an error
 func (x *GoSNMP) GetNext(oid string) (*SnmpPacket, error) {
-	var err error
-	defer func() {
-		if e := recover(); e != nil {
-			err = fmt.Errorf("%v", e)
-		}
-	}()
-
 	// Create the packet
 	packet := new(SnmpPacket)
 
@@ -260,13 +253,6 @@ func (x *GoSNMP) Debug(data []byte) (*SnmpPacket, error) {
 // GetBulk sends an SNMP BULK-GET request to the target. Returns a Variable with
 // the response or an error
 func (x *GoSNMP) GetBulk(nonRepeaters, maxRepetitions uint8, oids ...string) (*SnmpPacket, error) {
-	var err error
-	defer func() {
-		if e := recover(); e != nil {
-			err = fmt.Errorf("%v", e)
-		}
-	}()
-
 	// Create the packet
 	packet := new(SnmpPacket)
 
@@ -287,13 +273,6 @@ func (x *GoSNMP) GetBulk(nonRepeaters, maxRepetitions uint8, oids ...string) (*S
 // Get sends an SNMP GET request to the target. Returns a Variable with the
 // response or an error
 func (x *GoSNMP) Get(oid string) (*SnmpPacket, error) {
-	var err error
-	defer func() {
-		if e := recover(); e != nil {
-			err = fmt.Errorf("%v", e)
-		}
-	}()
-
 	// Create the packet
 	packet := new(SnmpPacket)
 
@@ -310,13 +289,6 @@ func (x *GoSNMP) Get(oid string) (*SnmpPacket, error) {
 // GetMulti sends an SNMP GET request to the target. Returns a Variable with the
 // response or an error
 func (x *GoSNMP) GetMulti(oids []string) (*SnmpPacket, error) {
-	var err error
-	defer func() {
-		if e := recover(); e != nil {
-			err = fmt.Errorf("%v", e)
-		}
-	}()
-
 	// Create the packet
 	packet := new(SnmpPacket)
 


### PR DESCRIPTION
The declaration `var err` is unused and it causes some static analysis tools (go
guru) to throw an error on this repository. I'm not sure what ought to be done
here, but consider this a start.

In fact, this ought to be a compile time error. See this issue for the go
runtime https://github.com/golang/go/issues/3059