### PR TITLE
bug fix

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -143,7 +143,7 @@ func parseInt(bytes []byte) (int, error) {
 func Uvarint(buf []byte) (x uint64) {
 	for i, b := range buf {
 		x = x<<8 + uint64(b)
-		if i == 7 {
+		if i == 8 {
 			return
 		}
 	}


### PR DESCRIPTION
when buf is a 9 bytes uint64,e.g:[0,255,255,255,255,255,210,210,105],call Uvarint will get wrong result because of missing the 9 byte